### PR TITLE
Feat: Add configurable Redis and Celery usage

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -44,7 +44,13 @@ BACKEND_CORS_ORIGINS=http://localhost:8000,http://127.0.0.1:8000
 # REDIS_PASSWORD=
 # REDIS_DB=0 # Номер бази даних Redis
 
+# --- Налаштування використання Redis та Celery ---
+# Встановіть True або False для ввімкнення/вимкнення відповідних сервісів
+USE_REDIS=True
+USE_CELERY=False
+
 # --- Налаштування Celery (опціонально, для фонових завдань) ---
+# Ці налаштування будуть використовуватися, якщо USE_CELERY=True
 # CELERY_BROKER_URL=redis://localhost:6379/0 # URL брокера повідомлень (наприклад, Redis або RabbitMQ)
 # CELERY_RESULT_BACKEND=redis://localhost:6379/0 # URL для зберігання результатів завдань
 

--- a/backend/.env.prod
+++ b/backend/.env.prod
@@ -29,7 +29,14 @@ REDIS_PORT=6379
 REDIS_PASSWORD=
 REDIS_DB=0
 
+# --- Налаштування використання Redis та Celery ---
+# Встановіть True або False для ввімкнення/вимкнення відповідних сервісів
+# Ці значення будуть завантажені в settings.py
+USE_REDIS=True
+USE_CELERY=False
+
 # --- Налаштування Celery (якщо використовується локально з Redis) ---
+# Ці налаштування будуть використовуватися, якщо USE_CELERY=True
 # CELERY_BROKER_URL=redis://${REDIS_HOST}:${REDIS_PORT}/${REDIS_DB}
 # CELERY_RESULT_BACKEND=redis://${REDIS_HOST}:${REDIS_PORT}/${REDIS_DB}
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -51,14 +51,23 @@ async def lifespan(current_app: FastAPI):
     setup_logging() # Застосовуємо конфігурацію логування
     logger.info(f"Запуск програми '{settings.PROJECT_NAME}' в середовищі '{settings.ENVIRONMENT}' з рівнем логування '{settings.LOGGING_LEVEL}'.")
 
-    # 2. Ініціалізація та перевірка з'єднання з Redis
-    try:
-        await get_redis_client() # Ініціалізує та перевіряє з'єднання
-        logger.info("Клієнт Redis успішно ініціалізовано та підключено.")
-    except Exception as e:
-        logger.error(f"Не вдалося ініціалізувати або підключитися до Redis під час запуску: {e}", exc_info=True)
-        # Залежно від критичності Redis, тут можна або продовжити роботу, або завершити програму.
-        # Наприклад: raise RuntimeError("Не вдалося підключитися до Redis, запуск програми скасовано.") from e
+    # 2. Ініціалізація та перевірка з'єднання з Redis (якщо увімкнено)
+    if settings.USE_REDIS:
+        try:
+            await get_redis_client() # Ініціалізує та перевіряє з'єднання
+            logger.info("Клієнт Redis успішно ініціалізовано та підключено (USE_REDIS=True).")
+        except Exception as e:
+            logger.error(f"Не вдалося ініціалізувати або підключитися до Redis під час запуску: {e}", exc_info=True)
+            # Залежно від критичності Redis, тут можна або продовжити роботу, або завершити програму.
+            # Наприклад: raise RuntimeError("Не вдалося підключитися до Redis, запуск програми скасовано.") from e
+    else:
+        logger.info("Використання Redis вимкнено (USE_REDIS=False). Пропуск ініціалізації клієнта Redis.")
+
+    # Логування стану використання Celery
+    if settings.USE_CELERY:
+        logger.info("Використання Celery увімкнено (USE_CELERY=True). Очікується, що Celery налаштовано та запущено окремо.")
+    else:
+        logger.info("Використання Celery вимкнено (USE_CELERY=False). Фонові завдання через Celery не будуть оброблятися.")
 
     # 3. Створення таблиць бази даних (ТІЛЬКИ для розробки/тестування, якщо не використовуються міграції Alembic)
     # УВАГА: У продакшен-середовищі для управління схемою БД слід використовувати Alembic.
@@ -80,9 +89,12 @@ async def lifespan(current_app: FastAPI):
     # --- Shutdown ---
     logger.info("Початок процесу завершення роботи програми Kudos...")
 
-    # 1. Закриття з'єднання з Redis
-    await close_redis_client()
-    logger.info("З'єднання з Redis закрито.")
+    # 1. Закриття з'єднання з Redis (якщо використовувався)
+    if settings.USE_REDIS:
+        await close_redis_client()
+        logger.info("З'єднання з Redis закрито (USE_REDIS=True).")
+    else:
+        logger.info("Використання Redis було вимкнено (USE_REDIS=False). Пропуск закриття з'єднання з Redis.")
 
     logger.info("Програма Kudos успішно завершила роботу.")
 

--- a/backend/app/src/api/dependencies.py
+++ b/backend/app/src/api/dependencies.py
@@ -251,26 +251,25 @@ async def get_cache_service() -> BaseCacheService:
     global _cache_service_instance
 
     if _cache_service_instance is None:
-        # TODO: Розглянути можливість вибору реалізації кешу (Redis/InMemory) через налаштування settings.CACHE_TYPE
-        # Поки що використовуємо RedisCacheService, якщо доступний, інакше InMemoryCacheService.
         logger.info("Створення нового екземпляра CacheService.")
-        if settings.REDIS_HOST and settings.REDIS_PORT: # Припускаємо, що ці налаштування є
+        if settings.USE_REDIS and settings.REDIS_HOST and settings.REDIS_PORT:
             try:
-                # Спроба ініціалізувати RedisCacheService
-                # RedisCacheService сам обробляє підключення до пулу
                 _cache_service_instance = RedisCacheService()
-                # Можна додати перевірку з'єднання тут, якщо потрібно
-                # await _cache_service_instance._get_client() # Тест з'єднання
-                logger.info("Використовується RedisCacheService.")
+                # Можна додати перевірку з'єднання тут, якщо потрібно, хоча RedisCacheService може робити це "ліниво"
+                # await _cache_service_instance._get_client() # Приклад перевірки
+                logger.info("Використовується RedisCacheService (USE_REDIS=True та налаштування Redis присутні).")
             except Exception as e:
                 logger.error(f"Помилка ініціалізації RedisCacheService: {e}. Перехід на InMemoryCacheService.")
                 _cache_service_instance = InMemoryCacheService()
-                logger.info("Використовується InMemoryCacheService як запасний варіант.")
+                logger.info("Використовується InMemoryCacheService як запасний варіант після невдалої ініціалізації Redis.")
         else:
+            if not settings.USE_REDIS:
+                logger.info("Використання Redis вимкнено (USE_REDIS=False). Використовується InMemoryCacheService.")
+            else: # USE_REDIS is True, але REDIS_HOST або REDIS_PORT не налаштовані
+                logger.info("Конфігурація Redis (REDIS_HOST/REDIS_PORT) не знайдена, хоча USE_REDIS=True. Використовується InMemoryCacheService.")
             _cache_service_instance = InMemoryCacheService()
-            logger.info("Конфігурація Redis не знайдена. Використовується InMemoryCacheService.")
 
-    if _cache_service_instance is None: # Якщо ініціалізація все ще не вдалася
+    if _cache_service_instance is None: # Якщо ініціалізація все ще не вдалася (малоймовірно після змін)
         logger.error("Не вдалося створити жоден екземпляр CacheService!")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Сервіс кешування недоступний.")
 

--- a/backend/app/src/config/settings.py
+++ b/backend/app/src/config/settings.py
@@ -151,6 +151,10 @@ class Settings(BaseSettings):
             return str(RedisDsn(f"{scheme}://:{values.get('REDIS_PASSWORD')}@{values.get('REDIS_HOST')}:{values.get('REDIS_PORT')}/{values.get('REDIS_DB')}"))
         return str(RedisDsn(f"{scheme}://{values.get('REDIS_HOST')}:{values.get('REDIS_PORT')}/{values.get('REDIS_DB')}"))
 
+    # --- Налаштування використання Redis та Celery ---
+    USE_REDIS: bool = True  # Чи використовувати Redis (для кешування, черг тощо)
+    USE_CELERY: bool = False # Чи використовувати Celery для фонових завдань (за замовчуванням False)
+
     # --- Налаштування JWT автентифікації ---
     # ВАЖЛИВО: Секретний ключ для генерації JWT токенів.
     # ПОТРІБНО ЗГЕНЕРУВАТИ НАДІЙНИЙ КЛЮЧ ТА ЗБЕРІГАТИ ЙОГО В БЕЗПЕЦІ!


### PR DESCRIPTION
Implemented a mechanism to enable or disable Redis and Celery functionality via environment variables.

Changes include:
- Added `USE_REDIS` (default: True) and `USE_CELERY` (default: False) boolean flags to `backend/app/src/config/settings.py`.
- Updated `backend/.env.example` and `backend/.env.prod` to include these new configuration variables.
- Modified Redis client initialization in `backend/app/main.py` (lifespan function) to only occur if `settings.USE_REDIS` is True.
- Updated the cache service dependency (`get_cache_service` in `backend/app/src/api/dependencies.py`) to use `RedisCacheService` only if `settings.USE_REDIS` is True and Redis is configured; otherwise, it falls back to `InMemoryCacheService`.
- Added logging in `backend/app/main.py` to indicate whether Celery usage is enabled or disabled based on `settings.USE_CELERY`. (No direct Celery integration points were modified as none were found actively using Celery tasks in the analyzed codebase).

This allows for more flexible deployment and local development setups where Redis or Celery might not be available or needed.