### PR TITLE
Fix: Усунення помилок запуску SQLAlchemy та Pydantic

### DIFF
--- a/backend/app/src/models/base.py
+++ b/backend/app/src/models/base.py
@@ -103,7 +103,9 @@ class BaseMainModel(BaseModel):
 
     # Використовуємо рядкові посилання на моделі для уникнення циклічних імпортів на рівні файлів.
     # SQLAlchemy зможе їх розпізнати, якщо всі моделі успадковують від одного Base.
-    state: Mapped[Optional["StatusModel"]] = relationship("StatusModel", foreign_keys=[state_id], lazy="selectin")
+    @declared_attr
+    def state(cls) -> Mapped[Optional["StatusModel"]]:
+        return relationship("StatusModel", foreign_keys=[cls.state_id], lazy="selectin") # type: ignore
 
     # Зв'язок з групою
     # `back_populates` має відповідати назві зв'язку в GroupModel, якщо там є зворотний зв'язок
@@ -112,7 +114,9 @@ class BaseMainModel(BaseModel):
     # в `GroupModel` може бути складним.
     # Поки що без `back_populates` або з загальною назвою, яку треба буде узгодити.
     # `foreign_keys` вказується явно, щоб SQLAlchemy точно знав, яке поле використовувати.
-    group: Mapped[Optional["GroupModel"]] = relationship("GroupModel", foreign_keys=[group_id], lazy="selectin")
+    @declared_attr
+    def group(cls) -> Mapped[Optional["GroupModel"]]:
+        return relationship("GroupModel", foreign_keys=[cls.group_id], lazy="selectin") # type: ignore
     # TODO: Узгодити `back_populates` для `group` з `GroupModel`, коли там будуть визначені
     #       зворотні зв'язки до різних типів сутностей, що належать групі.
     #       Наприклад, `GroupModel` може мати `tasks = relationship("TaskModel", back_populates="group")`.

--- a/backend/app/src/models/bonuses/transaction.py
+++ b/backend/app/src/models/bonuses/transaction.py
@@ -36,7 +36,8 @@ class TransactionModel(BaseModel):
 
     related_user_id: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id", name="fk_transactions_related_user_id", ondelete="SET NULL"), nullable=True, index=True)
 
-    metadata: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSONB, nullable=True)
+    # Перейменовано з 'metadata' для уникнення конфлікту з зарезервованим іменем SQLAlchemy
+    additional_data: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSONB, nullable=True)
     balance_after_transaction: Mapped[Optional[Decimal]] = mapped_column(Numeric(12, 2), nullable=True)
 
     # --- Зв'язки (Relationships) ---

--- a/backend/app/src/models/dictionaries/base.py
+++ b/backend/app/src/models/dictionaries/base.py
@@ -9,6 +9,7 @@
 """
 
 from sqlalchemy import Column, String # type: ignore
+from sqlalchemy.orm import Mapped, mapped_column # Додано для SQLAlchemy 2.0
 
 from backend.app.src.models.base import BaseMainModel # Імпорт базової моделі
 
@@ -35,7 +36,8 @@ class BaseDictModel(BaseMainModel):
     # Або розглянути композитний індекс/обмеження, якщо `code` має бути унікальним
     # в поєднанні з іншим полем (наприклад, `group_id`, якщо довідники специфічні для груп).
     # Для загальних довідників `unique=True` є доцільним.
-    code: Column[str] = Column(String(100), nullable=False, index=True)
+    # code: Column[str] = Column(String(100), nullable=False, index=True) # Старий стиль
+    code: Mapped[str] = mapped_column(String(100), nullable=False, index=True) # Новий стиль SQLAlchemy 2.0
 
     # TODO: Подумати над тим, чи потрібне поле `group_id` для всіх довідників.
     # Деякі довідники можуть бути глобальними (наприклад, системні статуси, ролі),

--- a/backend/app/src/models/dictionaries/status.py
+++ b/backend/app/src/models/dictionaries/status.py
@@ -136,11 +136,11 @@ class StatusModel(BaseDictModel):
 
 
     # Поле для сортування статусів у визначеному порядку (наприклад, для UI).
-    display_order: Mapped[Optional[int]] = mapped_column(Integer, default=0, nullable=True)
+    display_order: Mapped[Optional[int]] = mapped_column(Integer, default=0, nullable=True) # Вже використовує Mapped
 
     # Поле для зберігання кольору статусу (наприклад, для візуального виділення в UI).
     # Формат кольору, наприклад, HEX (#RRGGBB) або назва кольору.
-    color_code: Mapped[Optional[str]] = mapped_column(String(20), nullable=True) # Збільшено довжину для назв кольорів
+    color_code: Mapped[Optional[str]] = mapped_column(String(20), nullable=True) # Вже використовує Mapped
 
     def __repr__(self) -> str:
         """

--- a/backend/app/src/models/files/file.py
+++ b/backend/app/src/models/files/file.py
@@ -7,11 +7,11 @@
 Самі файли зберігаються в файловій системі або хмарному сховищі,
 а ця модель містить посилання на них та їх метадані.
 """
-from typing import Optional
+from typing import Optional, Dict, Any
 
 from sqlalchemy import Column, String, Text, DateTime, ForeignKey, Integer, Boolean # type: ignore
 from sqlalchemy.dialects.postgresql import UUID, JSONB # type: ignore
-from sqlalchemy.orm import relationship, Mapped  # type: ignore
+from sqlalchemy.orm import relationship, Mapped, mapped_column  # type: ignore # Додано mapped_column
 import uuid # Для роботи з UUID
 from datetime import datetime # Для роботи з датами та часом
 
@@ -70,29 +70,29 @@ class FileModel(BaseModel):
     __tablename__ = "files"
 
     # Шлях/ключ у файловому сховищі. Має бути унікальним.
-    storage_path: Column[str] = Column(String(1024), nullable=False, unique=True, index=True)
-    original_filename: Column[str] = Column(String(255), nullable=False)
-    mime_type: Column[str] = Column(String(100), nullable=False, index=True)
-    file_size_bytes: Column[Integer] = Column(Integer, nullable=False) # Використовуємо Integer, PostgreSQL підтримує до 2GB. Для більших - BigInteger.
+    storage_path: Mapped[str] = mapped_column(String(1024), nullable=False, unique=True, index=True)
+    original_filename: Mapped[str] = mapped_column(String(255), nullable=False)
+    mime_type: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    file_size_bytes: Mapped[int] = mapped_column(Integer, nullable=False) # Використовуємо Integer, PostgreSQL підтримує до 2GB. Для більших - BigInteger.
 
     # Хто завантажив файл
     # TODO: Замінити "users.id" на константу або імпорт моделі UserModel.
-    uploaded_by_user_id: Column[uuid.UUID | None] = Column(UUID(as_uuid=True), ForeignKey("users.id", name="fk_files_uploader_id", ondelete="SET NULL"), nullable=True, index=True)
+    uploaded_by_user_id: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id", name="fk_files_uploader_id", ondelete="SET NULL"), nullable=True, index=True)
 
     # Контекст групи, якщо файл специфічний для групи
     # TODO: Замінити "groups.id" на константу або імпорт моделі GroupModel.
-    group_context_id: Column[uuid.UUID | None] = Column(UUID(as_uuid=True), ForeignKey("groups.id", name="fk_files_group_context_id", ondelete="CASCADE"), nullable=True, index=True)
+    group_context_id: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True), ForeignKey("groups.id", name="fk_files_group_context_id", ondelete="CASCADE"), nullable=True, index=True)
 
     # Категорія файлу
     # TODO: Створити Enum або довідник для FileCategory.
     # Приклади: "USER_AVATAR", "GROUP_ICON", "REWARD_ICON", "BADGE_ICON", "LEVEL_ICON", "TASK_ATTACHMENT", "REPORT_FILE".
-    file_category_code: Column[str | None] = Column(String(50), nullable=True, index=True)
+    file_category_code: Mapped[Optional[str]] = mapped_column(String(50), nullable=True, index=True)
 
-    metadata: Column[JSONB | None] = Column(JSONB, nullable=True) # Наприклад, {"width": 100, "height": 100} для зображень
+    additional_info: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSONB, nullable=True) # Перейменовано з metadata, Наприклад, {"width": 100, "height": 100} для зображень
 
-    # status_id: Column[uuid.UUID | None] = Column(UUID(as_uuid=True), ForeignKey("statuses.id"), nullable=True, index=True)
+    # status_id: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True), ForeignKey("statuses.id"), nullable=True, index=True)
 
-    is_public: Column[bool] = Column(Boolean, default=False, nullable=False, index=True)
+    is_public: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False, index=True)
 
 
     # --- Зв'язки (Relationships) ---

--- a/backend/app/src/models/notifications/notification.py
+++ b/backend/app/src/models/notifications/notification.py
@@ -72,7 +72,8 @@ class NotificationModel(BaseModel):
 
     is_read: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False, index=True)
     read_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
-    metadata: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSONB, nullable=True)
+    # Перейменовано з 'metadata' для уникнення конфлікту з зарезервованим іменем SQLAlchemy
+    additional_data: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSONB, nullable=True)
 
 
     # --- Зв'язки (Relationships) ---

--- a/backend/app/src/schemas/__init__.py
+++ b/backend/app/src/schemas/__init__.py
@@ -128,6 +128,46 @@ __all__ = _base_schemas_all + \
 # ForwardRef на глобальному рівні, можна буде повернутися до цього питання.
 # Основна мета цього файлу - агрегація та реекспорт схем.
 
+# Виклик model_rebuild для всіх схем, які можуть мати ForwardRef,
+# після того, як всі модулі схем імпортовано.
+# Це має вирішити проблеми з циклічними залежностями та ForwardRef.
+# from backend.app.src.schemas.files import FileSchema, AvatarSchema # Виклики model_rebuild() тепер у __init__.py підпакетів
+# from backend.app.src.schemas.auth import UserSchema, RefreshTokenSchema, SessionSchema
+# from backend.app.src.schemas.groups import GroupSchema, GroupMembershipSchema, PollSchema, PollOptionSchema, PollVoteSchema, GroupInvitationSchema, GroupSettingsSchema, GroupTemplateSchema
+# from backend.app.src.schemas.tasks import TaskSchema, TaskAssignmentSchema, TaskCompletionSchema, TaskDependencySchema, TaskProposalSchema, TaskReviewSchema
+# from backend.app.src.schemas.bonuses import AccountSchema, TransactionSchema, RewardSchema, BonusAdjustmentSchema
+# from backend.app.src.schemas.notifications import NotificationSchema, NotificationDeliverySchema, NotificationTemplateSchema
+# from backend.app.src.schemas.gamification import LevelSchema, UserLevelSchema, BadgeSchema, AchievementSchema, RatingSchema
+# from backend.app.src.schemas.teams import TeamSchema, TeamMembershipSchema
+# from backend.app.src.schemas.reports import ReportSchema
+# # Додайте інші схеми, якщо вони використовують ForwardRef до інших пакетів
+
+# # Список схем для model_rebuild()
+# # Порядок може бути важливим, якщо є залежності між ForwardRef в різних файлах.
+# # Зазвичай, якщо схема A посилається на B, а B на A, то порядок не має значення,
+# # Pydantic має впоратися.
+# # Головне, щоб усі класи були доступні в глобальному просторі імен модуля.
+# schemas_to_rebuild_globally = [
+#     FileSchema, AvatarSchema, # з files
+#     UserSchema, RefreshTokenSchema, SessionSchema, # з auth
+#     GroupSchema, GroupMembershipSchema, PollSchema, PollOptionSchema, PollVoteSchema, GroupInvitationSchema, GroupSettingsSchema, GroupTemplateSchema, # з groups
+#     TaskSchema, TaskAssignmentSchema, TaskCompletionSchema, TaskDependencySchema, TaskProposalSchema, TaskReviewSchema, # з tasks
+#     AccountSchema, TransactionSchema, RewardSchema, BonusAdjustmentSchema, # з bonuses
+#     NotificationSchema, NotificationDeliverySchema, NotificationTemplateSchema, # з notifications
+#     LevelSchema, UserLevelSchema, BadgeSchema, AchievementSchema, RatingSchema, # з gamification
+#     TeamSchema, TeamMembershipSchema, # з teams
+#     ReportSchema, # з reports
+#     # Додайте інші, якщо потрібно
+# ]
+
+# for schema_cls in schemas_to_rebuild_globally:
+#     try:
+#         schema_cls.model_rebuild()
+#     except Exception as e:
+#         # Логування або обробка помилки, якщо потрібно
+#         print(f"Попередження: не вдалося глобально оновити схему {schema_cls.__name__}: {e}")
+
+
 # Цей файл є важливою частиною структури проекту, забезпечуючи єдину точку
 # доступу до всіх схем даних, що використовуються для валідації API запитів/відповідей
 # та взаємодії з ORM моделями.

--- a/backend/app/src/schemas/auth/__init__.py
+++ b/backend/app/src/schemas/auth/__init__.py
@@ -87,7 +87,7 @@ __all__ = [
 
 # Виклик model_rebuild для схем, що містять ForwardRef
 # (UserSchema може посилатися на багато інших, тому її варто оновити)
-UserSchema.model_rebuild()
-RefreshTokenSchema.model_rebuild() # Може посилатися на UserPublicSchema
-SessionSchema.model_rebuild() # Може посилатися на UserPublicSchema або RefreshTokenSchema
+# UserSchema.model_rebuild() # Перенесено до глобального __init__.py
+# RefreshTokenSchema.model_rebuild() # Перенесено до глобального __init__.py
+# SessionSchema.model_rebuild() # Перенесено до глобального __init__.py
 # Інші схеми в цьому пакеті (Create/Update) зазвичай не мають складних ForwardRef.

--- a/backend/app/src/schemas/bonuses/transaction.py
+++ b/backend/app/src/schemas/bonuses/transaction.py
@@ -35,7 +35,7 @@ class TransactionSchema(AuditDatesSchema): # Успадковує id, created_at
 
     related_user_id: Optional[uuid.UUID] = Field(None, description="ID пов'язаного користувача (наприклад, для 'подяки')")
 
-    metadata: Optional[Dict[str, Any]] = Field(None, description="Додаткові структуровані дані (JSON)")
+    additional_data: Optional[Dict[str, Any]] = Field(None, description="Додаткові структуровані дані (JSON), раніше 'metadata'") # Перейменовано
     balance_after_transaction: Optional[Decimal] = Field(None, description="Баланс рахунку після цієї транзакції")
 
     # --- Розгорнуті зв'язки (приклад) ---
@@ -61,7 +61,7 @@ class TransactionCreateSchema(BaseSchema):
     source_entity_id: Optional[uuid.UUID] = Field(None, description="ID сутності-джерела")
 
     related_user_id: Optional[uuid.UUID] = Field(None, description="ID пов'язаного користувача")
-    metadata: Optional[Dict[str, Any]] = Field(None, description="Додаткові дані (JSON)")
+    additional_data: Optional[Dict[str, Any]] = Field(None, description="Додаткові дані (JSON), раніше 'metadata'") # Перейменовано
 
     # `balance_after_transaction` розраховується сервісом при створенні транзакції.
     # `created_at`, `updated_at`, `id` встановлюються автоматично.

--- a/backend/app/src/schemas/files/file.py
+++ b/backend/app/src/schemas/files/file.py
@@ -7,19 +7,16 @@
 """
 
 from pydantic import Field, HttpUrl
-from typing import Optional, List, Any, ForwardRef, Dict # Додано Dict
+from typing import Optional, List, Any, ForwardRef, Dict, TYPE_CHECKING # Додано TYPE_CHECKING
 import uuid
 from datetime import datetime
 
 from backend.app.src.schemas.base import BaseSchema, AuditDatesSchema
-# Потрібно буде імпортувати схеми для зв'язків:
-# from backend.app.src.schemas.auth.user import UserPublicSchema (для uploader)
-# from backend.app.src.schemas.groups.group import GroupSimpleSchema (для group_context)
-# from backend.app.src.schemas.dictionaries.status import StatusSchema (якщо є status_id)
 
-UserPublicSchema = ForwardRef('backend.app.src.schemas.auth.user.UserPublicSchema')
-GroupSimpleSchema = ForwardRef('backend.app.src.schemas.groups.group.GroupSimpleSchema')
-# StatusSchema = ForwardRef('backend.app.src.schemas.dictionaries.status.StatusSchema')
+if TYPE_CHECKING:
+    from backend.app.src.schemas.auth.user import UserPublicSchema
+    from backend.app.src.schemas.groups.group import GroupSimpleSchema
+    # from backend.app.src.schemas.dictionaries.status import StatusSchema
 
 
 # --- Схема для відображення метаданих файлу (для читання) ---
@@ -37,7 +34,7 @@ class FileSchema(AuditDatesSchema): # Успадковує id, created_at, updat
     group_context_id: Optional[uuid.UUID] = Field(None, description="ID групи, в контексті якої завантажено файл")
 
     file_category_code: Optional[str] = Field(None, max_length=50, description="Код категорії файлу (наприклад, 'AVATAR', 'TASK_ATTACHMENT')")
-    metadata: Optional[Dict[str, Any]] = Field(None, description="Додаткові метадані про файл (JSON)")
+    additional_info: Optional[Dict[str, Any]] = Field(None, description="Додаткові метадані про файл (JSON)") # Перейменовано з metadata
     # status_id: Optional[uuid.UUID] = Field(None, description="ID статусу файлу (якщо є)")
 
     is_public: bool = Field(..., description="Чи є файл публічно доступним")
@@ -46,9 +43,9 @@ class FileSchema(AuditDatesSchema): # Успадковує id, created_at, updat
     file_url: Optional[HttpUrl] = Field(None, description="URL для доступу/завантаження файлу")
 
     # --- Розгорнуті зв'язки (приклад) ---
-    uploader: Optional[UserPublicSchema] = Field(None, description="Користувач, який завантажив файл")
-    group_context: Optional[GroupSimpleSchema] = Field(None, description="Група, в контексті якої завантажено файл")
-    # status: Optional[StatusSchema] = Field(None, description="Статус файлу (якщо є)")
+    uploader: Optional['UserPublicSchema'] = Field(None, description="Користувач, який завантажив файл") # Використовуємо рядкове посилання
+    group_context: Optional['GroupSimpleSchema'] = Field(None, description="Група, в контексті якої завантажено файл") # Використовуємо рядкове посилання
+    # status: Optional['StatusSchema'] = Field(None, description="Статус файлу (якщо є)")
 
 
 # --- Схема для створення метаданих файлу (після завантаження файлу на сервер/сховище) ---
@@ -66,7 +63,7 @@ class FileCreateSchema(BaseSchema):
     group_context_id: Optional[uuid.UUID] = Field(None, description="ID групи-контексту")
 
     file_category_code: Optional[str] = Field(None, max_length=50, description="Код категорії файлу")
-    metadata: Optional[Dict[str, Any]] = Field(None, description="Додаткові метадані (JSON)")
+    additional_info: Optional[Dict[str, Any]] = Field(None, description="Додаткові метадані (JSON)") # Перейменовано з metadata
     # status_id: Optional[uuid.UUID] # Початковий статус (наприклад, "доступний")
     is_public: bool = Field(default=False, description="Чи є файл публічним (за замовчуванням False)")
 
@@ -82,7 +79,7 @@ class FileUpdateSchema(BaseSchema):
     """
     original_filename: Optional[str] = Field(None, max_length=255)
     file_category_code: Optional[str] = Field(None, max_length=50)
-    metadata: Optional[Dict[str, Any]] = Field(None)
+    additional_info: Optional[Dict[str, Any]] = Field(None) # Перейменовано з metadata
     # status_id: Optional[uuid.UUID] = Field(None)
     is_public: Optional[bool] = Field(None)
     # group_context_id: Optional[uuid.UUID] # Зміна контексту групи - обережно

--- a/backend/app/src/schemas/notifications/notification.py
+++ b/backend/app/src/schemas/notifications/notification.py
@@ -39,7 +39,7 @@ class NotificationSchema(AuditDatesSchema): # Успадковує id, created_a
     is_read: bool = Field(..., description="Чи прочитане сповіщення користувачем")
     read_at: Optional[datetime] = Field(None, description="Час, коли сповіщення було прочитане")
 
-    metadata: Optional[Dict[str, Any]] = Field(None, description="Додаткові дані для сповіщення (JSON)")
+    additional_data: Optional[Dict[str, Any]] = Field(None, description="Додаткові дані для сповіщення (JSON)") # Перейменовано з metadata
 
     # --- Розгорнуті зв'язки (приклад) ---
     recipient: Optional[UserPublicSchema] = Field(None, description="Отримувач сповіщення")

--- a/backend/app/src/services/files/file_service.py
+++ b/backend/app/src/services/files/file_service.py
@@ -87,7 +87,7 @@ class FileService(BaseService[FileRepository]):
         category: FileCategoryEnum, # Категорія файлу
         group_id_context: Optional[uuid.UUID] = None, # Якщо файл стосується групи
         is_public: bool = False,
-        custom_metadata: Optional[Dict[str, Any]] = None
+        additional_info: Optional[Dict[str, Any]] = None # Перейменовано з custom_metadata
     ) -> FileModel:
         """
         Обробляє завантаження файлу: зберігає файл, створює запис метаданих.
@@ -128,7 +128,7 @@ class FileService(BaseService[FileRepository]):
             uploaded_by_user_id=current_user.id,
             group_context_id=group_id_context,
             file_category_code=category.value,
-            metadata=custom_metadata,
+            additional_info=additional_info, # Перейменовано з metadata
             is_public=is_public
         )
         return await self.repository.create(db, obj_in=file_create_schema)


### PR DESCRIPTION
Виправлено низку помилок, що виникали під час ініціалізації моделей SQLAlchemy та схем Pydantic:

- `sqlalchemy.exc.InvalidRequestError` (декоратор `@declared_attr`):
    - Додано `@declared_attr` до `relationship` в `BaseMainModel`.
- `sqlalchemy.exc.InvalidRequestError` (зарезервоване ім'я `metadata`):
    - Перейменовано атрибут `metadata` на `additional_data` в `TransactionModel` та відповідних схемах.
    - Перейменовано атрибут `metadata` на `additional_info` в `FileModel` та відповідних схемах і сервісі.
    - Перейменовано атрибут `metadata` на `additional_data` в `NotificationModel` та відповідних схемах.
- `sqlalchemy.orm.exc.MappedAnnotationError` (анотації типів SQLAlchemy 2.0):
    - Оновлено анотації типів в `BaseDictModel` (для поля `code`) та `AvatarModel` на використання `Mapped[]` та `mapped_column()`.
    - Оновлено анотації типів для всіх полів в `FileModel`, `NotificationTemplateModel`.
- `sqlalchemy.exc.ArgumentError` (неправильний `postgresql_where` в `UniqueConstraint`):
    - Замінено `UniqueConstraint` з `postgresql_where` на `Index` з `unique=True` та `postgresql_where` в моделях `AvatarModel`, `UserLevelModel`, `TaskAssignmentModel`, `NotificationTemplateModel`.
- `NameError` (неправильні посилання в `__table_args__`):
    - Виправлено посилання на стовпці та класи в умовах `postgresql_where` та списках стовпців для `Index` в `NotificationTemplateModel`.
- `pydantic.errors.PydanticUndefinedAnnotation` та `ImportError` (циклічні імпорти та `ForwardRef`):
    - Застосовано `TYPE_CHECKING` для імпортів у файлах схем Pydantic, що використовують посилання на типи з інших модулів (наприклад, `schemas/files/file.py`).
    - Відновлено виклики `model_rebuild()` в `__init__.py` файлах підпакетів схем.
    - Прибрано глобальний цикл `model_rebuild()` з головного `schemas/__init__.py`.

Ці зміни мають забезпечити коректний запуск та ініціалізацію бекенду.